### PR TITLE
Add setting for including other than 'published' states in schedule

### DIFF
--- a/backend/news/4.feature
+++ b/backend/news/4.feature
@@ -1,0 +1,1 @@
+Add setting for including other than 'published' states in schedule. @datakurre

--- a/backend/src/collective/techevent/behaviors/tech_event.py
+++ b/backend/src/collective/techevent/behaviors/tech_event.py
@@ -148,6 +148,7 @@ class ISettings(model.Schema):
             "durations_keynote",
             "durations_talk",
             "durations_training",
+            "schedule_review_states",
         ],
     )
 
@@ -273,6 +274,26 @@ class ISettings(model.Schema):
         },
     )
 
+    schedule_review_states = schema.List(
+        title=_("Schedule: Additional states"),
+        description=_(
+            "Workflow states to include in the schedule in addition to 'published'."
+        ),
+        required=False,
+        value_type=schema.Choice(
+            vocabulary="plone.app.vocabularies.WorkflowStates",
+        ),
+    )
+    directives.widget(
+        "schedule_review_states",
+        frontendOptions={
+            "widget": "multiSelect",
+            "widgetProps": {
+                "multiple": True,
+            },
+        },
+    )
+
 
 @implementer(ISettings)
 class Settings:
@@ -375,3 +396,13 @@ class Settings:
     def days(self, value: list):
         """Setter, called by the form, set on context."""
         pass
+
+    @property
+    def schedule_review_states(self) -> list[str]:
+        """Getter, read workflow states from context and return back"""
+        return getattr(self.context, "schedule_review_states", None) or []
+
+    @schedule_review_states.setter
+    def schedule_review_states(self, value: list[str]):
+        """Setter, called by the form, set workflow states on context."""
+        self.context.schedule_review_states = list(value or [])

--- a/backend/src/collective/techevent/services/schedule/get.py
+++ b/backend/src/collective/techevent/services/schedule/get.py
@@ -112,10 +112,11 @@ class ScheduleGet(Service):
 
     def get_slots(self) -> list[dict[str, Any]]:
         portal = api.portal.get()
+        review_states = getattr(self.context, "schedule_review_states", None)
         results = api.content.find(
             context=portal,
             object_provides=IScheduleSlot,
-            review_state="published",
+            review_state=list(set(review_states or []).union({"published"})),
             sort_on="start",
             sort_order="ascending",
         )

--- a/backend/tests/services/conftest.py
+++ b/backend/tests/services/conftest.py
@@ -1,0 +1,44 @@
+from collective.techevent import PACKAGE_NAME
+from plone import api
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.restapi.testing import RelativeSession
+from Products.GenericSetup.tool import SetupTool
+from zope.component.hooks import setSite
+
+import pytest
+import transaction
+
+
+@pytest.fixture()
+def portal(functional):
+    portal = functional["portal"]
+    setSite(portal)
+    tool: SetupTool = api.portal.get_tool("portal_setup")
+    with api.env.adopt_roles(["Manager", "Member"]):
+        tool.runAllImportStepsFromProfile(f"{PACKAGE_NAME}:demo")
+    transaction.commit()
+    return portal
+
+
+@pytest.fixture()
+def request_api_factory(portal):
+    def factory():
+        url = portal.absolute_url()
+        api_session = RelativeSession(f"{url}/++api++")
+        return api_session
+
+    return factory
+
+
+@pytest.fixture()
+def api_anon_request(request_api_factory):
+    return request_api_factory()
+
+
+@pytest.fixture()
+def api_manager_request(request_api_factory):
+    request = request_api_factory()
+    request.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+    yield request
+    request.auth = ()

--- a/backend/tests/services/test_service_schedule.py
+++ b/backend/tests/services/test_service_schedule.py
@@ -1,0 +1,80 @@
+from collective.techevent.utils import find_event_root
+from plone import api
+
+import pytest
+import transaction
+
+
+def total_event_count(response: dict) -> int:
+    """Return total number of events in the schedule."""
+    count = 0
+    for day in response.get("items", []):
+        for hour in day.get("items", []):
+            count += len(hour.get("items", []))
+    return count
+
+
+class TestScheduleGet:
+    @pytest.fixture(autouse=True)
+    def _setup(self, portal):
+        self.portal = portal
+        self.schedule = portal["schedule"]
+
+    def test_schedule_public(self, api_anon_request, api_manager_request):
+        # By default, the schedule shows only published events, which shows
+        # the same amount of events for anonymous and managers.
+        event_root = find_event_root(self.schedule)
+        event_root.schedule_review_states = []
+        transaction.commit()
+
+        anon_response = api_anon_request.get("@schedule")
+        assert anon_response.status_code == 200
+        anon_event_count = total_event_count(anon_response.json())
+
+        manager_response = api_manager_request.get("@schedule")
+        assert manager_response.status_code == 200
+        manager_event_count = total_event_count(manager_response.json())
+
+        assert anon_event_count > 0
+        assert manager_event_count > 0
+        assert anon_event_count == manager_event_count > 0
+
+    def test_schedule_private(self, api_anon_request, api_manager_request):
+        # When the schedule is partly private, anonymous users should see
+        # the same amount of events as managers
+
+        event_root = find_event_root(self.schedule)
+        for ob in api.content.find(context=self.schedule, portal_type=["Talk"]):
+            api.content.transition(ob.getObject(), transition="retract")
+        transaction.commit()
+
+        anon_response = api_anon_request.get("@schedule")
+        assert anon_response.status_code == 200
+        anon_event_count = total_event_count(anon_response.json())
+
+        manager_response = api_manager_request.get("@schedule")
+        assert manager_response.status_code == 200
+        manager_event_count = total_event_count(manager_response.json())
+
+        assert anon_event_count > 0
+        assert manager_event_count > 0
+        assert anon_event_count == manager_event_count > 0
+
+        # unless the schedule is configured to show private events. Then
+        # anonymous users should still see only published events, but
+        # managers should see all events.
+
+        event_root.schedule_review_states = ["published", "private"]
+        transaction.commit()
+
+        anon_response = api_anon_request.get("@schedule")
+        assert anon_response.status_code == 200
+        anon_event_count = total_event_count(anon_response.json())
+
+        manager_response = api_manager_request.get("@schedule")
+        assert manager_response.status_code == 200
+        manager_event_count = total_event_count(manager_response.json())
+
+        assert anon_event_count > 0
+        assert manager_event_count > 0
+        assert anon_event_count < manager_event_count

--- a/frontend/packages/volto-techevent/news/4.feature
+++ b/frontend/packages/volto-techevent/news/4.feature
@@ -1,0 +1,1 @@
+Add state-{review_state} class name into sessionTile. @datakurre

--- a/frontend/packages/volto-techevent/src/components/Schedule/SessionTile.tsx
+++ b/frontend/packages/volto-techevent/src/components/Schedule/SessionTile.tsx
@@ -29,7 +29,9 @@ const SessionTile: React.FC<SessionTileProps> = ({
   const type = item['@type'];
 
   return (
-    <Container className={`sessionTile ${type} ${uid}`}>
+    <Container
+      className={`sessionTile ${type} ${uid} state-${item.review_state}`}
+    >
       <SessionTrack item={item} />
       <SessionMetadata item={item} shortDate={shortDate} showRoom={showRoom} />
       <Container className="sessionData">


### PR DESCRIPTION
This should support drafting the schedule directly on the site before fully publishing it or updates to it.