### PR TITLE
Support filtering Session and Presenter content items

### DIFF
--- a/backend/news/+catalog.feature
+++ b/backend/news/+catalog.feature
@@ -1,0 +1,1 @@
+Adds new indexes slot_room, session_level, session_track, session_audience, session_language, presenter_categories to the catalog. @ericof

--- a/backend/news/+qs.feature
+++ b/backend/news/+qs.feature
@@ -1,0 +1,1 @@
+Adds new querystring filters. @ericof

--- a/backend/src/collective/techevent/indexers/configure.zcml
+++ b/backend/src/collective/techevent/indexers/configure.zcml
@@ -1,14 +1,46 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
-  <!-- Indexers/Metadata -->
+  <!-- Indexers -->
+  <!-- Slot -->
+  <adapter
+      factory=".slot.slot_room_indexer"
+      name="slot_room"
+      />
+
+  <!-- Session -->
+  <adapter
+      factory=".session.session_track_indexer"
+      name="session_track"
+      />
+  <adapter
+      factory=".session.session_level_indexer"
+      name="session_level"
+      />
+  <adapter
+      factory=".session.session_audience_indexer"
+      name="session_audience"
+      />
+  <adapter
+      factory=".session.session_language_indexer"
+      name="session_language"
+      />
+
+  <!-- Presenter -->
+  <adapter
+      factory=".presenter.categories_indexer"
+      name="presenter_categories"
+      />
+
+  <!-- Sponsor -->
+  <adapter
+      factory=".sponsor.level_indexer"
+      name="level"
+      />
 
   <!-- -*- extra stuff goes here -*- -->
   <adapter
       factory=".social_links.links_indexer"
       name="links"
       />
-  <adapter
-      factory=".sponsor.level_indexer"
-      name="level"
-      />
+
 </configure>

--- a/backend/src/collective/techevent/indexers/presenter.py
+++ b/backend/src/collective/techevent/indexers/presenter.py
@@ -1,0 +1,9 @@
+from collective.techevent.content.presenter import IPresenter
+from plone.indexer.decorator import indexer
+
+
+@indexer(IPresenter)
+def categories_indexer(obj) -> list[str] | None:
+    """Indexer used to index category information."""
+    if categories := obj.categories:
+        return list(categories)

--- a/backend/src/collective/techevent/indexers/session.py
+++ b/backend/src/collective/techevent/indexers/session.py
@@ -1,0 +1,31 @@
+from collective.techevent.content.schedule.session import ISession
+from plone.indexer.decorator import indexer
+
+
+@indexer(ISession)
+def session_track_indexer(obj) -> list[str] | None:
+    """Indexer used to index session_track information."""
+    if track := obj.session_track:
+        return list(track)
+
+
+@indexer(ISession)
+def session_level_indexer(obj) -> list[str] | None:
+    """Indexer used to index session_level information."""
+    if level := obj.session_level:
+        return list(level)
+
+
+@indexer(ISession)
+def session_audience_indexer(obj) -> list[str] | None:
+    """Indexer used to index session_audience information."""
+    if audience := obj.session_audience:
+        return list(audience)
+
+
+@indexer(ISession)
+def session_language_indexer(obj) -> str | None:
+    """Indexer used to index session_language information."""
+    language = obj.session_language
+    if language is not None:
+        return language

--- a/backend/src/collective/techevent/indexers/slot.py
+++ b/backend/src/collective/techevent/indexers/slot.py
@@ -1,0 +1,9 @@
+from collective.techevent.behaviors.schedule import IScheduleSlot
+from plone.indexer.decorator import indexer
+
+
+@indexer(IScheduleSlot)
+def slot_room_indexer(obj) -> list[str]:
+    """Indexer used to index room information."""
+    room = obj.room or set()
+    return list(room) if room else []

--- a/backend/src/collective/techevent/profiles/default/catalog.xml
+++ b/backend/src/collective/techevent/profiles/default/catalog.xml
@@ -2,12 +2,48 @@
 <object name="portal_catalog">
 
   <!-- Indexes -->
+  <!-- Sponsors -->
   <index meta_type="FieldIndex"
          name="level"
   >
     <indexed_attr value="level" />
   </index>
 
+  <!-- Slot -->
+  <index meta_type="KeywordIndex"
+         name="slot_room"
+  >
+    <indexed_attr value="slot_room" />
+  </index>
+
+  <!-- Sessions -->
+  <index meta_type="KeywordIndex"
+         name="session_level"
+  >
+    <indexed_attr value="session_level" />
+  </index>
+  <index meta_type="KeywordIndex"
+         name="session_track"
+  >
+    <indexed_attr value="session_track" />
+  </index>
+  <index meta_type="KeywordIndex"
+         name="session_audience"
+  >
+    <indexed_attr value="session_audience" />
+  </index>
+  <index meta_type="FieldIndex"
+         name="session_language"
+  >
+    <indexed_attr value="session_language" />
+  </index>
+
+  <!-- Presenters -->
+  <index meta_type="KeywordIndex"
+         name="presenter_categories"
+  >
+    <indexed_attr value="presenter_categories" />
+  </index>
 
 
   <!-- Metadata -->

--- a/backend/src/collective/techevent/profiles/default/metadata.xml
+++ b/backend/src/collective/techevent/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1006</version>
+  <version>1007</version>
   <dependencies>
     <dependency>profile-plone.volto:default</dependency>
   </dependencies>

--- a/backend/src/collective/techevent/profiles/default/registry/plone.app.querystring.interfaces.IQueryField.xml
+++ b/backend/src/collective/techevent/profiles/default/registry/plone.app.querystring.interfaces.IQueryField.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="collective.techevent"
+>
+
+
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.slot_room"
+  >
+    <value key="title"
+           i18n:translate=""
+    >Room</value>
+    <value key="description"
+           i18n:translate=""
+    >Room for a slot.</value>
+    <value key="enabled">True</value>
+    <value key="sortable">False</value>
+    <value key="operations">
+      <element>plone.app.querystring.operation.selection.any</element>
+      <element>plone.app.querystring.operation.selection.all</element>
+    </value>
+    <value key="vocabulary">collective.techevent.vocabularies.slot_rooms</value>
+    <value key="group"
+           i18n:translate=""
+    >Event Schedule</value>
+  </records>
+
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.session_level"
+  >
+    <value key="title"
+           i18n:translate=""
+    >Level</value>
+    <value key="description"
+           i18n:translate=""
+    >Session Level.</value>
+    <value key="enabled">True</value>
+    <value key="sortable">False</value>
+    <value key="operations">
+      <element>plone.app.querystring.operation.selection.any</element>
+      <element>plone.app.querystring.operation.selection.all</element>
+    </value>
+    <value key="vocabulary">collective.techevent.vocabularies.session_levels</value>
+    <value key="group"
+           i18n:translate=""
+    >Event Schedule</value>
+  </records>
+
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.session_audience"
+  >
+    <value key="title"
+           i18n:translate=""
+    >Audience</value>
+    <value key="description"
+           i18n:translate=""
+    >Target Audience.</value>
+    <value key="enabled">True</value>
+    <value key="sortable">False</value>
+    <value key="operations">
+      <element>plone.app.querystring.operation.selection.any</element>
+      <element>plone.app.querystring.operation.selection.all</element>
+    </value>
+    <value key="vocabulary">collective.techevent.vocabularies.session_audiences</value>
+    <value key="group"
+           i18n:translate=""
+    >Event Schedule</value>
+  </records>
+
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.session_track"
+  >
+    <value key="title"
+           i18n:translate=""
+    >Track</value>
+    <value key="description"
+           i18n:translate=""
+    >Session Track.</value>
+    <value key="enabled">True</value>
+    <value key="sortable">False</value>
+    <value key="operations">
+      <element>plone.app.querystring.operation.selection.any</element>
+      <element>plone.app.querystring.operation.selection.all</element>
+    </value>
+    <value key="vocabulary">collective.techevent.vocabularies.session_tracks</value>
+    <value key="group"
+           i18n:translate=""
+    >Event Schedule</value>
+  </records>
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.session_language"
+  >
+    <value key="title"
+           i18n:translate=""
+    >Language</value>
+    <value key="description"
+           i18n:translate=""
+    >Session Language.</value>
+    <value key="enabled">True</value>
+    <value key="sortable">False</value>
+    <value key="operations">
+      <element>plone.app.querystring.operation.selection.any</element>
+      <element>plone.app.querystring.operation.selection.all</element>
+    </value>
+    <value key="vocabulary">plone.app.vocabularies.SupportedContentLanguages</value>
+    <value key="group"
+           i18n:translate=""
+    >Event Schedule</value>
+  </records>
+
+
+  <!-- Presenter -->
+  <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.presenter_categories"
+  >
+    <value key="title"
+           i18n:translate=""
+    >Category</value>
+    <value key="description"
+           i18n:translate=""
+    >Presenter Category.</value>
+    <value key="enabled">True</value>
+    <value key="sortable">False</value>
+    <value key="operations">
+      <element>plone.app.querystring.operation.selection.any</element>
+      <element>plone.app.querystring.operation.selection.all</element>
+    </value>
+    <value key="vocabulary">collective.techevent.vocabularies.presenter_labels</value>
+    <value key="group"
+           i18n:translate=""
+    >Event Presenters</value>
+  </records>
+
+</registry>

--- a/backend/src/collective/techevent/upgrades/configure.zcml
+++ b/backend/src/collective/techevent/upgrades/configure.zcml
@@ -6,6 +6,7 @@
   <include package=".v1004" />
   <include package=".v1005" />
   <include package=".v1006" />
+  <include package=".v1007" />
 
   <!-- -*- extra stuff goes here -*- -->
 

--- a/backend/src/collective/techevent/upgrades/v1007/__init__.py
+++ b/backend/src/collective/techevent/upgrades/v1007/__init__.py
@@ -1,0 +1,32 @@
+from collective.techevent import logger
+from collective.techevent.utils.permissions import modify_schedule_permissions
+from plone import api
+from Products.GenericSetup.tool import SetupTool
+
+
+def reindex_schedule_objects(context: SetupTool):
+    idxs = [
+        "slot_room",
+        "session_level",
+        "session_audience",
+        "session_track",
+        "session_language",
+    ]
+    brains = api.content.find(
+        portal_type=["Talk", "Keynote", "Training", "LightningTalks", "OpenSpace"]
+    )
+    for brain in brains:
+        obj = brain.getObject()
+        obj.reindexObject(idxs)
+        logger.info(f"Reindexed {', '.join(idxs)} {obj.absolute_url()}")
+
+
+def reindex_presenter_objects(context: SetupTool):
+    idxs = [
+        "presenter_categories",
+    ]
+    brains = api.content.find(portal_type=["Presenter"])
+    for brain in brains:
+        obj = brain.getObject()
+        obj.reindexObject(idxs)
+        logger.info(f"Reindexed {', '.join(idxs)} {obj.absolute_url()}")

--- a/backend/src/collective/techevent/upgrades/v1007/configure.zcml
+++ b/backend/src/collective/techevent/upgrades/v1007/configure.zcml
@@ -1,0 +1,25 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+
+  <genericsetup:upgradeSteps
+      profile="collective.techevent:default"
+      source="1006"
+      destination="1007"
+      >
+    <genericsetup:upgradeDepends
+        title="Add catalog indexes, querystring entries"
+        import_steps="catalog plone.app.registry"
+        />
+    <genericsetup:upgradeStep
+        title="Reindex Session objects"
+        handler=".reindex_schedule_objects"
+        />
+    <genericsetup:upgradeStep
+        title="Reindex Presenter objects"
+        handler=".reindex_presenter_objects"
+        />
+  </genericsetup:upgradeSteps>
+
+</configure>

--- a/backend/tests/_resources/content.json
+++ b/backend/tests/_resources/content.json
@@ -13,6 +13,7 @@
       "id": "ericof",
       "title": "Érico Andrei",
       "description": "Awesome location for our event",
+      "categories": ["keynote-speaker", "instructor"],
       "social_links": [
           {
               "@id": "ee320a12-4f2b-4450-8214-61facb451000",
@@ -113,6 +114,10 @@
       "description": "Plone API talk",
       "start": "2025-08-01T17:05:00",
       "end": "2025-08-01T17:50:00",
+      "session_audience": ["developers"],
+      "session_language": "en",
+      "session_level": ["general"],
+      "session_track": ["main"],
       "duration": "long"
   },
   {

--- a/backend/tests/content_types/schedule/test_ct_talk.py
+++ b/backend/tests/content_types/schedule/test_ct_talk.py
@@ -63,6 +63,22 @@ class TestContentType:
         uids = [brain.UID for brain in results]
         assert content_instance.UID() in uids
 
+    @pytest.mark.parametrize(
+        "key,value,expected",
+        [
+            ["session_audience", "developers", True],
+            ["session_track", "main", True],
+            ["session_level", "general", True],
+            ["session_language", "en", True],
+        ],
+    )
+    def test_indexer_session(
+        self, catalog, content_instance, key: str, value: str, expected: bool
+    ):
+        query = {"UID": content_instance.UID(), key: value}
+        brains = catalog(**query)
+        assert (len(brains) == 1) is expected
+
 
 class TestVersioning:
     @pytest.fixture(autouse=True)

--- a/backend/tests/content_types/test_ct_presenter.py
+++ b/backend/tests/content_types/test_ct_presenter.py
@@ -51,6 +51,21 @@ class TestContentType:
         assert isinstance(links, list)
         assert len(links) == 2
 
+    @pytest.mark.parametrize(
+        "category,expected",
+        [
+            ["keynote-speaker", True],
+            ["instructor", True],
+            ["foobar", False],
+        ],
+    )
+    def test_indexer_categories(
+        self, catalog, content_instance, category: str, expected: bool
+    ):
+        query = {"UID": content_instance.UID(), "presenter_categories": category}
+        brains = catalog(**query)
+        assert (len(brains) == 1) is expected
+
 
 class TestVersioning:
     @pytest.fixture(autouse=True)

--- a/backend/tests/setup/test_setup_install.py
+++ b/backend/tests/setup/test_setup_install.py
@@ -14,4 +14,4 @@ class TestSetupInstall:
 
     def test_latest_version(self, profile_last_version):
         """Test latest version of default profile."""
-        assert profile_last_version(f"{PACKAGE_NAME}:default") == "1006"
+        assert profile_last_version(f"{PACKAGE_NAME}:default") == "1007"

--- a/backend/tests/setup/test_setup_registry.py
+++ b/backend/tests/setup/test_setup_registry.py
@@ -35,5 +35,119 @@ class TestRegistryValues:
         ],
     )
     def test_plone_displayed_types(self, item: str, expected: bool):
-        value = api.portal.get_registry_record("plone.displayed_types")
+        value: list[str] = api.portal.get_registry_record("plone.displayed_types")
         assert (item in value) is expected
+
+    @pytest.mark.parametrize(
+        "field_name,key,expected",
+        [
+            ("slot_room", "title", "Room"),
+            ("slot_room", "description", "Room for a slot."),
+            ("slot_room", "enabled", True),
+            ("slot_room", "sortable", False),
+            (
+                "slot_room",
+                "operations",
+                [
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.all",
+                ],
+            ),
+            ("slot_room", "vocabulary", "collective.techevent.vocabularies.slot_rooms"),
+            ("slot_room", "group", "Event Schedule"),
+            ("session_level", "title", "Level"),
+            ("session_level", "description", "Session Level."),
+            ("session_level", "enabled", True),
+            ("session_level", "sortable", False),
+            (
+                "session_level",
+                "operations",
+                [
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.all",
+                ],
+            ),
+            (
+                "session_level",
+                "vocabulary",
+                "collective.techevent.vocabularies.session_levels",
+            ),
+            ("session_level", "group", "Event Schedule"),
+            ("session_audience", "title", "Audience"),
+            ("session_audience", "description", "Target Audience."),
+            ("session_audience", "enabled", True),
+            ("session_audience", "sortable", False),
+            (
+                "session_audience",
+                "operations",
+                [
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.all",
+                ],
+            ),
+            (
+                "session_audience",
+                "vocabulary",
+                "collective.techevent.vocabularies.session_audiences",
+            ),
+            ("session_audience", "group", "Event Schedule"),
+            ("session_track", "title", "Track"),
+            ("session_track", "description", "Session Track."),
+            ("session_track", "enabled", True),
+            ("session_track", "sortable", False),
+            (
+                "session_track",
+                "operations",
+                [
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.all",
+                ],
+            ),
+            (
+                "session_track",
+                "vocabulary",
+                "collective.techevent.vocabularies.session_tracks",
+            ),
+            ("session_track", "group", "Event Schedule"),
+            ("session_language", "title", "Language"),
+            ("session_language", "description", "Session Language."),
+            ("session_language", "enabled", True),
+            ("session_language", "sortable", False),
+            (
+                "session_language",
+                "operations",
+                [
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.all",
+                ],
+            ),
+            (
+                "session_language",
+                "vocabulary",
+                "plone.app.vocabularies.SupportedContentLanguages",
+            ),
+            ("session_language", "group", "Event Schedule"),
+            ("presenter_categories", "title", "Category"),
+            ("presenter_categories", "description", "Presenter Category."),
+            ("presenter_categories", "enabled", True),
+            ("presenter_categories", "sortable", False),
+            (
+                "presenter_categories",
+                "operations",
+                [
+                    "plone.app.querystring.operation.selection.any",
+                    "plone.app.querystring.operation.selection.all",
+                ],
+            ),
+            (
+                "presenter_categories",
+                "vocabulary",
+                "collective.techevent.vocabularies.presenter_labels",
+            ),
+            ("presenter_categories", "group", "Event Presenters"),
+        ],
+    )
+    def test_plone_qs_field(self, field_name: str, key: str, expected):
+        reg_key = f"plone.app.querystring.field.{field_name}.{key}"
+        value = api.portal.get_registry_record(reg_key)
+        assert value == expected


### PR DESCRIPTION
Fixes #9

@datakurre This PR implements one of the last major features from 2024.ploneconf.org that was missing from TechEvent: The ability to filter Session and Presenter content using the catalog (via code) and listing / search blocks in the Volto interface.