### PR TITLE
Fix SessionTrack component to display all selected tracks

### DIFF
--- a/frontend/packages/volto-techevent/news/15.bugfix
+++ b/frontend/packages/volto-techevent/news/15.bugfix
@@ -1,0 +1,1 @@
+ Fix SessionTrack component to display all selected tracks @datakurre

--- a/frontend/packages/volto-techevent/src/components/Schedule/SessionTrack.tsx
+++ b/frontend/packages/volto-techevent/src/components/Schedule/SessionTrack.tsx
@@ -7,20 +7,31 @@ interface SessionTrackProps {
 }
 
 const SessionTrack: React.FC<SessionTrackProps> = ({ item }) => {
-  const track = item?.session_track?.length > 0 ? item.session_track[0] : null;
-  const token = track?.token;
-  const title = track?.title;
   const colors = useVocabularyColors('tracks');
-  const value = colors?.[token] || 'unset';
+  const tracks = item?.session_track || [];
   return (
-    token && (
-      <div
-        className="sessionTrack"
-        style={{ '--vocabulary-background-color': value }}
-      >
-        <div className={`track ${token}`}>{title}</div>
-      </div>
-    )
+    <>
+      {tracks.map((track) => {
+        const token = track?.token;
+        const title = track?.title;
+        const value = colors?.[token] || 'unset';
+        return (
+          token && (
+            <div
+              key={token}
+              className="sessionTrack"
+              style={
+                {
+                  ['--vocabulary-background-color' as any]: value,
+                } as React.CSSProperties
+              }
+            >
+              <div className={`track ${token}`}>{title}</div>
+            </div>
+          )
+        );
+      })}
+    </>
   );
 };
 


### PR DESCRIPTION
Talks allow multiple tracks to be selected, so maybe all of them should be shown. Even it is a bad idea in the beginning and schedule would get messy. 