### PR TITLE
Fix to not hide Keynote presenters on schedule

### DIFF
--- a/frontend/packages/volto-techevent/news/20.bugfix
+++ b/frontend/packages/volto-techevent/news/20.bugfix
@@ -1,0 +1,1 @@
+Fix to not hide Keynote presenters on schedule. @datakurre

--- a/frontend/packages/volto-techevent/src/theme/components/schedule/_schedule.scss
+++ b/frontend/packages/volto-techevent/src/theme/components/schedule/_schedule.scss
@@ -134,11 +134,6 @@
         }
       }
     }
-    &.room-all {
-      .sessionBody {
-        display: none;
-      }
-    }
   }
 
   .tab {


### PR DESCRIPTION
All room slot had their body hidden on schedule, but the body (mainly presenters) would be empty already for breaks and other slots, so this only accidentally hide Keynote speakers, because currently Keynotes are shown as "all room" events to make them pop.