### PR TITLE
Show rooms on schedule tiles

### DIFF
--- a/frontend/packages/volto-techevent/news/21.feature
+++ b/frontend/packages/volto-techevent/news/21.feature
@@ -1,0 +1,1 @@
+Change to show rooms on every schedule slot @datakurre

--- a/frontend/packages/volto-techevent/src/components/Schedule/DaySchedule.tsx
+++ b/frontend/packages/volto-techevent/src/components/Schedule/DaySchedule.tsx
@@ -199,7 +199,7 @@ const DaySchedule = (props) => {
                   <Tile
                     item={slot}
                     shortDate
-                    showRoom={false}
+                    showRoom={true}
                     showDescription={true}
                     gridColumn={slot.gridColumn}
                     gridRow={slot.gridRow}

--- a/frontend/packages/volto-techevent/src/theme/components/schedule/_schedule.scss
+++ b/frontend/packages/volto-techevent/src/theme/components/schedule/_schedule.scss
@@ -73,6 +73,14 @@
       flex-grow: 1;
       padding: $spacing-2xsmall 0 $spacing-small 0;
       margin: 0 var(--techevent-schedule-gap);
+      .slotRoom {
+        .title {
+          font-size: 14px;
+        }
+        .categoryIcon {
+          height: 14px !important;
+        }
+      }
       .sessionDescription {
         display: None;
       }


### PR DESCRIPTION
Room were hidden on reason, I believe. Should this be configurable? Yet, this would be required information for mobile layouts and would also help the usual layout when the rooms are long been hidden with scroll. (I did not implement the floating track header for schedules.)